### PR TITLE
Ruby LSP extension

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -7,6 +7,7 @@ module Literal
 	Loader = Zeitwerk::Loader.for_gem.tap do |loader|
 		loader.ignore("#{__dir__}/literal/rails")
 		loader.ignore("#{__dir__}/literal/railtie.rb")
+		loader.ignore("#{__dir__}/ruby_lsp")
 
 		loader.inflector.inflect(
 			"json_data_type" => "JSONDataType"

--- a/lib/ruby_lsp/literal/addon.rb
+++ b/lib/ruby_lsp/literal/addon.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "ruby_lsp/addon"
+
+module RubyLsp
+	module Literal
+		class Addon < ::RubyLsp::Addon
+			def activate(global_state, message_queue)
+			end
+
+			def deactivate
+			end
+
+			def name
+				"Literal"
+			end
+
+			def version
+				"0.1.0"
+			end
+		end
+
+		class MyIndexingEnhancement < RubyIndexer::Enhancement
+			def on_call_node_enter(node)
+				return unless @listener.current_owner
+				return unless node.name == :prop
+				location = node.location
+
+				arguments = node.arguments.arguments
+
+				args = arguments.reject { |it| it.is_a?(Prism::KeywordHashNode) }
+				kwargs = arguments.find { |it| it.is_a?(Prism::KeywordHashNode) }&.elements&.to_h do |element|
+					[
+						(
+							case element.key
+							in Prism::SymbolNode[unescaped: String => key]
+								key
+							end
+						),
+						element.value,
+					]
+				end
+
+				kwargs ||= []
+
+				name, type, kind = args
+
+				case [name, type, kind]
+				in [Prism::SymbolNode[unescaped: String => prop_name], _, _]
+					owner = @listener.current_owner
+					@listener.instance_exec do
+						@index.add(RubyIndexer::Entry::InstanceVariable.new(
+							"@#{prop_name}",
+							@uri,
+							RubyIndexer::Location.from_prism_location(node.location, @code_units_cache),
+							collect_comments(node),
+							owner,
+						))
+					end
+
+					if kwargs["reader"] in Prism::SymbolNode[unescaped: "private" | "protected" | "public" => visibility]
+						@listener.add_method(prop_name, location, [
+							RubyIndexer::Entry::Signature.new([]),
+						], visibility: visibility.to_sym)
+					end
+
+					if kwargs["writer"] in Prism::SymbolNode[unescaped: "private" | "protected" | "public" => visibility]
+						@listener.add_method("#{prop_name}=", location, [
+							RubyIndexer::Entry::Signature.new([
+								RubyIndexer::Entry::RequiredParameter.new(name: "value"),
+							]),
+						], visibility: visibility.to_sym)
+					end
+				end
+			end
+		end
+	end
+end


### PR DESCRIPTION
Set up basic Ruby LSP add-on. This add-on defines instance variables when you use the `prop` macro. It also sets up reader and writer methods with the correct visibility, but only when you specify them directly in the macro.