### PR TITLE
Change behavior of Enum's to_s and to_sym methods

### DIFF
--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -200,12 +200,12 @@ class Literal::Enum
 
 	alias_method :inspect, :name
 
-	def to_s
-		self.class.names[self].name
-	end
-
 	def to_sym
 		self.class.names[self]
+	end
+
+	def to_s
+		to_sym.to_s
 	end
 
 	def deconstruct

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -201,7 +201,7 @@ class Literal::Enum
 	alias_method :inspect, :name
 
 	def to_s
-		self.class.names[self].name.underscore.humanize
+		self.class.names[self].name
 	end
 
 	def to_sym

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -201,7 +201,11 @@ class Literal::Enum
 	alias_method :inspect, :name
 
 	def to_s
-		name.split("::").last.underscore.humanize
+		name.demodulize.underscore.humanize
+	end
+
+	def to_sym
+		name.demodulize.to_sym
 	end
 
 	def deconstruct

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -201,11 +201,11 @@ class Literal::Enum
 	alias_method :inspect, :name
 
 	def to_s
-		name.demodulize.underscore.humanize
+		self.class.names[self].name.underscore.humanize
 	end
 
 	def to_sym
-		name.demodulize.to_sym
+		self.class.names[self]
 	end
 
 	def deconstruct

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -199,7 +199,10 @@ class Literal::Enum
 	end
 
 	alias_method :inspect, :name
-	alias_method :to_s, :name
+
+	def to_s
+		name.split("::").last.underscore.humanize
+	end
 
 	def deconstruct
 		[@value]

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -109,7 +109,7 @@ test ".to_set" do
 		Color::Red,
 		Color::Green,
 		Color::Blue,
-		Color::SPRING_GREEN,
+		Color::SPRING_GREEN
 	]
 end
 

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -15,7 +15,6 @@ class Color < Literal::Enum(Integer)
 	Green = new(2, hex: "#00FF00")
 	Blue = new(3, hex: "#0000FF")
 	SPRING_GREEN = new(4, hex: "#00FF7F")
-	SlateGray = new(5, hex: "#333333")
 
 	__after_defined__ if RUBY_ENGINE == "truffleruby"
 end
@@ -111,7 +110,6 @@ test ".to_set" do
 		Color::Green,
 		Color::Blue,
 		Color::SPRING_GREEN,
-		Color::SlateGray
 	]
 end
 
@@ -121,7 +119,6 @@ test ".to_h without block" do
 		Color::Green => 2,
 		Color::Blue => 3,
 		Color::SPRING_GREEN => 4,
-		Color::SlateGray => 5,
 	}
 end
 
@@ -135,8 +132,7 @@ end
 
 test ".to_s" do
 	assert_equal Color::Red.to_s, "Red"
-	assert_equal Color::SPRING_GREEN.to_s, "Spring green"
-	assert_equal Color::SlateGray.to_s, "Slate gray"
+	assert_equal Color::SPRING_GREEN.to_s, "SPRING_GREEN"
 	assert_equal Switch::On.to_s, "On"
 	assert_equal SymbolTypedEnum::A.to_s, "A"
 end
@@ -144,7 +140,6 @@ end
 test ".to_sym" do
 	assert_equal Color::Red.to_sym, :Red
 	assert_equal Color::SPRING_GREEN.to_sym, :SPRING_GREEN
-	assert_equal Color::SlateGray.to_sym, :SlateGray
 	assert_equal Switch::On.to_sym, :On
 	assert_equal SymbolTypedEnum::A.to_sym, :A
 end
@@ -153,8 +148,7 @@ test "#succ" do
 	assert_equal Color::Red.succ, Color::Green
 	assert_equal Color::Green.succ, Color::Blue
 	assert_equal Color::Blue.succ, Color::SPRING_GREEN
-	assert_equal Color::SPRING_GREEN.succ, Color::SlateGray
-	assert_equal Color::SlateGray.succ, nil
+	assert_equal Color::SPRING_GREEN.succ, nil
 end
 
 test "#pred" do

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -15,6 +15,7 @@ class Color < Literal::Enum(Integer)
 	Green = new(2, hex: "#00FF00")
 	Blue = new(3, hex: "#0000FF")
 	SPRING_GREEN = new(4, hex: "#00FF7F")
+	SlateGray = new(5, hex: "#333333")
 
 	__after_defined__ if RUBY_ENGINE == "truffleruby"
 end
@@ -109,7 +110,8 @@ test ".to_set" do
 		Color::Red,
 		Color::Green,
 		Color::Blue,
-		Color::SPRING_GREEN
+		Color::SPRING_GREEN,
+		Color::SlateGray
 	]
 end
 
@@ -119,6 +121,7 @@ test ".to_h without block" do
 		Color::Green => 2,
 		Color::Blue => 3,
 		Color::SPRING_GREEN => 4,
+		Color::SlateGray => 5,
 	}
 end
 
@@ -130,11 +133,20 @@ test ".to_proc coerces" do
 	]
 end
 
+test ".to_s" do
+	assert_equal Color::Red.to_s, "Red"
+	assert_equal Color::SPRING_GREEN.to_s, "Spring green"
+	assert_equal Color::SlateGray.to_s, "Slate gray"
+	assert_equal Switch::On.to_s, "On"
+	assert_equal SymbolTypedEnum::A.to_s, "A"
+end
+
 test "#succ" do
 	assert_equal Color::Red.succ, Color::Green
 	assert_equal Color::Green.succ, Color::Blue
 	assert_equal Color::Blue.succ, Color::SPRING_GREEN
-	assert_equal Color::SPRING_GREEN.succ, nil
+	assert_equal Color::SPRING_GREEN.succ, Color::SlateGray
+	assert_equal Color::SlateGray.succ, nil
 end
 
 test "#pred" do

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -141,6 +141,14 @@ test ".to_s" do
 	assert_equal SymbolTypedEnum::A.to_s, "A"
 end
 
+test ".to_sym" do
+	assert_equal Color::Red.to_sym, :Red
+	assert_equal Color::SPRING_GREEN.to_sym, :SPRING_GREEN
+	assert_equal Color::SlateGray.to_sym, :SlateGray
+	assert_equal Switch::On.to_sym, :On
+	assert_equal SymbolTypedEnum::A.to_sym, :A
+end
+
 test "#succ" do
 	assert_equal Color::Red.succ, Color::Green
 	assert_equal Color::Green.succ, Color::Blue


### PR DESCRIPTION
This changes the behavior of `to_s` and `to_sym` on Enums.

`to_s` returns a humanized version of the demodularized class name, eg: "Red," "Slate gray," "Spring green"

`to_sym` converts the demodularized class name to a symbol, eg: `:Red`, `:SlateGray`, `:SPRING_GREEN`

Note that this was deemed a minor breaking change.