### PR TITLE
Fixes "Literal::TypeError::Context does not define to_h"

### DIFF
--- a/lib/literal/errors/type_error.rb
+++ b/lib/literal/errors/type_error.rb
@@ -41,6 +41,19 @@ class Literal::TypeError < TypeError
 			expected.record_literal_type_errors(child) if expected.respond_to?(:record_literal_type_errors)
 			@children << child
 		end
+
+		def to_h
+			{
+						receiver: @receiver,
+						method: @method,
+						label: @label,
+						expected: @expected,
+						actual: @actual,
+						children: @children,
+				}
+		end
+
+		alias to_hash to_h
 	end
 
 	def initialize(context:)
@@ -71,6 +84,10 @@ class Literal::TypeError < TypeError
 			end
 		end
 		message
+	end
+
+	def deconstruct
+		to_h.values
 	end
 
 	def deconstruct_keys(keys)

--- a/test/type_error.test.rb
+++ b/test/type_error.test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+Age = Literal::Value(Integer, 18..)
+
+test do
+	Age.new(17)
+rescue => error
+	assert_equal error.class, Literal::TypeError
+	assert_equal error.message, "Type mismatch\n\n" \
+		"    _Constraint(Integer, 18..)\n" \
+		"      Expected: 18..\n" \
+		"      Actual (Integer): 17\n"
+
+	# deconstruct_keys
+	key_names = [:receiver, :method, :label, :actual]
+	exp_keys = {
+				receiver: nil,
+				method: nil,
+				label: nil,
+				actual: 17,
+		}
+	assert_equal error.deconstruct_keys(key_names), exp_keys
+
+	# deconstruct
+	expected_value = error.deconstruct
+	assert_equal expected_value.size, 6
+	assert_equal expected_value[0], nil
+	assert_equal expected_value[1], nil
+	assert_equal expected_value[2], nil # "_Constraint(Integer, 18..)"
+	assert_equal expected_value[3].class, Literal::Types::ConstraintType
+	assert_equal expected_value[4], 17
+	assert_equal expected_value[5].class, Array
+	assert_equal expected_value[5].first.class, Literal::TypeError::Context
+end


### PR DESCRIPTION
Based on conversation at [Issue #328](https://github.com/yippee-fun/literal/issues/328) "Literal::TypeError::Context does not define to_h".

Fixes error for missing `Literal::TypeError::Context#to_h` and adds `deconstruct` to `Literal::TypeError` to more fully pattern match on type errors.