### PR TITLE
Introspection for properties and splat properties always 'default'

### DIFF
--- a/lib/literal/properties/introspection.rb
+++ b/lib/literal/properties/introspection.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Literal::Properties::Introspection
+	def positional_properties
+		literal_properties.filter(&:positional?)
+	end
+
+	def keyword_properties
+		literal_properties.filter(&:keyword?)
+	end
+
+	def required_properties
+		literal_properties.filter(&:required?)
+	end
+
+	def required_positional_properties
+		required_properties.filter(&:positional?)
+	end
+
+	def required_keyword_properties
+		required_properties.filter(&:keyword?)
+	end
+
+	def optional_positional_properties
+		positional_properties - required_positional_properties
+	end
+
+	def optional_keyword_properties
+		keyword_properties - required_keyword_properties
+	end
+
+	def positional_property_names
+		positional_properties.map(&:name)
+	end
+
+	def keyword_property_names
+		keyword_properties.map(&:name)
+	end
+
+	def required_property_names
+		required_properties.map(&:name)
+	end
+
+	def required_positional_property_names
+		required_positional_properties.map(&:name)
+	end
+
+	def required_keyword_property_names
+		required_keyword_properties.map(&:name)
+	end
+
+	def optional_positional_property_names
+		optional_positional_properties.map(&:name)
+	end
+
+	def optional_keyword_property_names
+		optional_keyword_properties.map(&:name)
+	end
+end

--- a/lib/literal/property.rb
+++ b/lib/literal/property.rb
@@ -51,7 +51,7 @@ class Literal::Property
 	end
 
 	def default?
-    return true if splat? || double_splat?
+		return true if splat? || double_splat?
 		nil != @default
 	end
 

--- a/lib/literal/property.rb
+++ b/lib/literal/property.rb
@@ -51,6 +51,7 @@ class Literal::Property
 	end
 
 	def default?
+    return true if splat? || double_splat?
 		nil != @default
 	end
 

--- a/test/properties.test.rb
+++ b/test/properties.test.rb
@@ -46,7 +46,7 @@ test "positional splats are optional" do
 	refute_raises { example.new }
 	refute_raises { example.new("Hello") }
 	refute_raises { example.new("Hello", "World") }
-  refute example.literal_properties[:example].required? { "Expected example to not be required" }
+	refute example.literal_properties[:example].required? { "Expected example to not be required" }
 end
 
 test "keyword splats are optional" do
@@ -57,7 +57,7 @@ test "keyword splats are optional" do
 	refute_raises { example.new }
 	refute_raises { example.new(example: "Hello") }
 	refute_raises { example.new(example: "Hello", world: "World") }
-  refute example.literal_properties[:example].required? { "Expected example to not be required" }
+	refute example.literal_properties[:example].required? { "Expected example to not be required" }
 end
 
 test "block params are required by default" do

--- a/test/properties.test.rb
+++ b/test/properties.test.rb
@@ -46,6 +46,7 @@ test "positional splats are optional" do
 	refute_raises { example.new }
 	refute_raises { example.new("Hello") }
 	refute_raises { example.new("Hello", "World") }
+  refute example.literal_properties[:example].required? { "Expected example to not be required" }
 end
 
 test "keyword splats are optional" do
@@ -56,6 +57,7 @@ test "keyword splats are optional" do
 	refute_raises { example.new }
 	refute_raises { example.new(example: "Hello") }
 	refute_raises { example.new(example: "Hello", world: "World") }
+  refute example.literal_properties[:example].required? { "Expected example to not be required" }
 end
 
 test "block params are required by default" do

--- a/test/properties/introspection.test.rb
+++ b/test/properties/introspection.test.rb
@@ -55,7 +55,6 @@ end
 
 test "required_properties returns all required properties" do
 	props = BasicIntrospection.required_properties
-  puts props.inspect
 	assert_equal props.map(&:name), [:id, :name, :age]
 	assert props.all?(&:required?)
 end

--- a/test/properties/introspection.test.rb
+++ b/test/properties/introspection.test.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+class BasicIntrospection
+	extend Literal::Properties
+	extend Literal::Properties::Introspection
+
+	prop :id, Integer, :positional
+	prop :name, String, :positional
+	prop :age, Integer
+	prop :email, _Nilable(String)
+	prop :friends, _Array(String), :*
+	prop :options, _Hash(Symbol, String), :**
+	prop :block, _Nilable(Proc), :&
+end
+
+class WithOptionals
+	extend Literal::Properties
+	extend Literal::Properties::Introspection
+
+	prop :required_pos, String, :positional
+	prop :optional_pos, String, :positional, default: "default"
+	prop :optional_name, _Nilable(String), :positional
+	prop :required_kw, Integer
+	prop :optional_kw, Integer, default: 42
+	prop :tags, _Array(String), default: -> { [] }
+	prop :created_at, _Nilable(Time)
+end
+
+class EmptyWithIntrospection
+	extend Literal::Properties
+	extend Literal::Properties::Introspection
+end
+
+test "positional_properties returns all positional properties" do
+	props = BasicIntrospection.positional_properties
+	assert_equal props.map(&:name), [:id, :name]
+	assert props.all?(&:positional?)
+end
+
+test "positional_property_names returns all positional property names" do
+	names = BasicIntrospection.positional_property_names
+	assert_equal names, [:id, :name]
+end
+
+test "keyword_properties returns all keyword properties" do
+	props = BasicIntrospection.keyword_properties
+	assert_equal props.map(&:name), [:age, :email]
+	assert props.all?(&:keyword?)
+end
+
+test "keyword_property_names returns all keyword property names" do
+	names = BasicIntrospection.keyword_property_names
+	assert_equal names, [:age, :email]
+end
+
+test "required_properties returns all required properties" do
+	props = BasicIntrospection.required_properties
+  puts props.inspect
+	assert_equal props.map(&:name), [:id, :name, :age]
+	assert props.all?(&:required?)
+end
+
+test "required_property_names returns all required property names" do
+	names = BasicIntrospection.required_property_names
+	assert_equal names, [:id, :name, :age]
+end
+
+test "required_positional_properties returns only required positional properties" do
+	props = BasicIntrospection.required_positional_properties
+	assert_equal props.map(&:name), [:id, :name]
+	assert props.all? { |p| p.required? && p.positional? }
+end
+
+test "required_positional_property_names returns only required positional property names" do
+	names = BasicIntrospection.required_positional_property_names
+	assert_equal names, [:id, :name]
+end
+
+test "required_keyword_properties returns only required keyword properties" do
+	props = BasicIntrospection.required_keyword_properties
+	assert_equal props.map(&:name), [:age]
+	assert props.all? { |p| p.required? && p.keyword? }
+end
+
+test "required_keyword_property_names returns only required keyword property names" do
+	names = BasicIntrospection.required_keyword_property_names
+	assert_equal names, [:age]
+end
+
+test "optional_positional_properties returns positional properties that are not required" do
+	props = WithOptionals.optional_positional_properties
+	assert_equal props.map(&:name), [:optional_pos, :optional_name]
+	assert props.all? { |p| p.positional? && !p.required? }
+end
+
+test "optional_positional_property_names returns optional positional property names" do
+	names = WithOptionals.optional_positional_property_names
+	assert_equal names, [:optional_pos, :optional_name]
+end
+
+test "optional_keyword_properties returns keyword properties that are not required" do
+	props = WithOptionals.optional_keyword_properties
+	assert_equal props.map(&:name), [:optional_kw, :tags, :created_at]
+	assert props.all? { |p| p.keyword? && !p.required? }
+end
+
+test "optional_keyword_property_names returns optional keyword property names" do
+	names = WithOptionals.optional_keyword_property_names
+	assert_equal names, [:optional_kw, :tags, :created_at]
+end
+
+test "empty class returns empty arrays for all methods" do
+	assert_equal EmptyWithIntrospection.positional_properties, []
+	assert_equal EmptyWithIntrospection.keyword_properties, []
+	assert_equal EmptyWithIntrospection.required_properties, []
+	assert_equal EmptyWithIntrospection.required_positional_properties, []
+	assert_equal EmptyWithIntrospection.required_keyword_properties, []
+	assert_equal EmptyWithIntrospection.optional_positional_properties, []
+	assert_equal EmptyWithIntrospection.optional_keyword_properties, []
+
+	assert_equal EmptyWithIntrospection.positional_property_names, []
+	assert_equal EmptyWithIntrospection.keyword_property_names, []
+	assert_equal EmptyWithIntrospection.required_property_names, []
+	assert_equal EmptyWithIntrospection.required_positional_property_names, []
+	assert_equal EmptyWithIntrospection.required_keyword_property_names, []
+	assert_equal EmptyWithIntrospection.optional_positional_property_names, []
+	assert_equal EmptyWithIntrospection.optional_keyword_property_names, []
+end
+
+test "splat parameters are not included in positional or keyword properties" do
+	positional_names = BasicIntrospection.positional_property_names
+	refute positional_names.include?(:friends)
+
+	keyword_names = BasicIntrospection.keyword_property_names
+	refute keyword_names.include?(:options)
+end
+
+test "block parameters are not included in any property lists" do
+	all_names = BasicIntrospection.positional_property_names + BasicIntrospection.keyword_property_names
+	refute all_names.include?(:block)
+end
+
+test "nilable positional properties are considered optional" do
+	required_names = WithOptionals.required_positional_property_names
+	optional_names = WithOptionals.optional_positional_property_names
+
+	assert_equal required_names, [:required_pos]
+	assert_equal optional_names, [:optional_pos, :optional_name]
+end
+
+test "mixed property types with defaults and nilables" do
+	assert_equal WithOptionals.positional_property_names, [:required_pos, :optional_pos, :optional_name]
+	assert_equal WithOptionals.keyword_property_names, [:required_kw, :optional_kw, :tags, :created_at]
+	assert_equal WithOptionals.required_positional_property_names, [:required_pos]
+	assert_equal WithOptionals.required_keyword_property_names, [:required_kw]
+	assert_equal WithOptionals.optional_positional_property_names, [:optional_pos, :optional_name]
+	assert_equal WithOptionals.optional_keyword_property_names, [:optional_kw, :tags, :created_at]
+end


### PR DESCRIPTION
This PR also includes a change of behaviour around `default?` in `Property` , as splat type arguments always default to empty array or hash respectively. I think that makes them feel more "correct". What do you think?