### PR TITLE
Implement Literal::Data.define

### DIFF
--- a/lib/literal/data.rb
+++ b/lib/literal/data.rb
@@ -2,6 +2,12 @@
 
 class Literal::Data < Literal::DataStructure
 	class << self
+		def define(**properties)
+			Class.new(self) do
+				properties.each { |name, type| prop(name, type) }
+			end
+		end
+
 		def prop(name, type, kind = :keyword, reader: :public, predicate: false, default: nil)
 			super(name, type, kind, reader:, writer: false, predicate:, default:)
 		end

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -82,3 +82,10 @@ test "empty" do
 	assert_equal(empty.eql?(other_empty), false)
 	assert_equal(empty.hash != other_empty.hash, true)
 end
+
+test "define" do
+	person_with_define = Literal::Data.define(name: String).new(name: "John")
+	person = Person.new(name: "John")
+
+	assert_equal(person_with_define.to_h, person.to_h)
+end


### PR DESCRIPTION
Proposal:

It would be nice to have a `define` like the [native Data structure](https://docs.ruby-lang.org/en/master/Data.html). It is useful for code like this:

```ruby
# Before
class CreateUser 
  Success = Class.new(Literal::Data) do
    prop :user, User
  end
  
  Failure = Class.new(Literal::Data) do
    prop :reason, Symbol
    prop :user, User
  end
end

# After
class CreateUser 
  Success = Literal::Data.define(user: User)
  Failure = Literal::Data.define(reason: Symbol, user: User)
end
```

With this define, we lose the ability to specify kind, reader, predicate, and default values, but I believe the goal is to provide a straightforward way to define simple data structures.