### PR TITLE
Allow `[]` to initialize Literal::Data

### DIFF
--- a/lib/literal/data.rb
+++ b/lib/literal/data.rb
@@ -2,6 +2,8 @@
 
 class Literal::Data < Literal::DataStructure
 	class << self
+		def [](...) = new(...)
+
 		def prop(name, type, kind = :keyword, reader: :public, predicate: false, default: nil)
 			super(name, type, kind, reader:, writer: false, predicate:, default:)
 		end

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -82,3 +82,10 @@ test "empty" do
 	assert_equal(empty.eql?(other_empty), false)
 	assert_equal(empty.hash != other_empty.hash, true)
 end
+
+test "initialize with [] method" do
+	person_a = Person.new(name: "John")
+	person_b = Person[name: "John"]
+
+	assert_equal(person_a, person_b)
+end


### PR DESCRIPTION
Proposal:

[Native Data structure](https://docs.ruby-lang.org/en/master/Data.html#method-c-new) allows objects to be instantied using `[]`, eg.
```ruby
Measure = Data.define(:amount, :unit)

Measure.new(amount: 1, unit: 'km')
#=> #<data Measure amount=1, unit="km">

Measure[amount: 1, unit: 'km']
#=> #<data Measure amount=1, unit="km">
```

I think Literal::Data should allow this syntax too to have an DX closer to native Data structure. It was the first way I tried to instance a Literal::Data and I got an error `undefined method '[]' for class Xyz`.