### PR TITLE
Update documentation with forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # A Literal Ruby Gem
 
+[![Ruby Users Forum](https://img.shields.io/discourse/topics?server=https%3A%2F%2Fwww.rubyforum.org&style=flat&logo=discourse&label=Ruby%20Users%20Forum)](https://www.rubyforum.org/tag/literal)
+
 See the website for [documentation](https://literal.fun/docs/).

--- a/literal.gemspec
+++ b/literal.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 	spec.metadata["source_code_uri"] = "https://github.com/joeldrapper/literal"
 	spec.metadata["changelog_uri"] = "https://github.com/joeldrapper/literal/releases"
 	spec.metadata["funding_uri"] = "https://github.com/sponsors/joeldrapper"
+	spec.metadata["mailing_list_uri"]   = "https://www.rubyforum.org/tag/literal"
 
 	spec.files = Dir[
 		"README.md",


### PR DESCRIPTION
Adding a badge with a link to the forum. Happy to make any updates or adjustments as needed.

It might be good to disable the github discussions to avoid any confusion too.

Finally, I noticed that the website nav was updated with the link to the forum here: https://github.com/yippee-fun/literal.fun/commit/f1ec8d902f0cc03a066d6d134cc61b304d64611b, but it's not showing up on the website: https://literal.fun