### PR TITLE
Add const: a property fixed at definition, not construction

### DIFF
--- a/lib/literal/data.rb
+++ b/lib/literal/data.rb
@@ -32,6 +32,10 @@ class Literal::Data < Literal::DataStructure
 			)
 		end
 
+		def const(name, value, reader: :public, description: nil)
+			prop(name, value, :const, reader:, default: value, description:)
+		end
+
 		def literal_properties
 			return @literal_properties if defined?(@literal_properties)
 

--- a/lib/literal/draft.rb
+++ b/lib/literal/draft.rb
@@ -101,6 +101,10 @@ class Literal::Draft < Literal::Struct
 		end
 
 		private def __draft_property__(property)
+			if property.const?
+				return const(property.name, property.default, description: property.description)
+			end
+
 			original_coercion = property.coercion
 
 			prop(

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -15,6 +15,10 @@ class Literal::Enum
 			super(name, type, kind, reader:, writer: false, predicate:, default:, description:)
 		end
 
+		def const(name, value, reader: :public, description: nil)
+			prop(name, value, :const, reader:, default: value, description:)
+		end
+
 		# Members are idiomatically defined above the checks in the class body,
 		# so `check` judges them before it installs.
 		private def __literal_existing_instances__

--- a/lib/literal/properties.rb
+++ b/lib/literal/properties.rb
@@ -172,6 +172,10 @@ module Literal::Properties
 		prop(name, _Union(type, Literal::Undefined), kind, reader:, writer:, predicate:, description:, &coercion)
 	end
 
+	def const(name, value, reader: false, description: nil)
+		prop(name, value, :const, reader:, writer: false, default: value, description:)
+	end
+
 	def prop(name, type, kind = :keyword, reader: false, writer: false, predicate: false, default: nil, description: nil, &coercion)
 		seal = nil
 
@@ -211,6 +215,20 @@ module Literal::Properties
 
 		unless Literal::Property::KIND_OPTIONS.include?(kind)
 			raise Literal::ArgumentError.new("The kind must be one of #{Literal::Property::KIND_OPTIONS.map(&:inspect).join(', ')}.")
+		end
+
+		if :const == kind
+			if default in nil | Proc
+				raise Literal::ArgumentError.new("The value for #{name.inspect} must be a frozen object, not nil or a Proc.")
+			end
+
+			if writer
+				raise Literal::ArgumentError.new("A const cannot have a writer.")
+			end
+
+			if coercion || seal
+				raise Literal::ArgumentError.new("A const cannot have a coercion or a seal.")
+			end
 		end
 
 		unless description.nil? || String === description

--- a/lib/literal/properties/schema.rb
+++ b/lib/literal/properties/schema.rb
@@ -132,10 +132,10 @@ class Literal::Properties::Schema
 	end
 
 	private def generate_initializer_params(buffer = +"")
-		sorted_properties = @sorted_properties
-		i, n = 0, sorted_properties.size
+		parameters = @sorted_properties.reject(&:const?)
+		i, n = 0, parameters.size
 		while i < n
-			property = sorted_properties[i]
+			property = parameters[i]
 
 			case property.kind
 			when :*

--- a/lib/literal/property.rb
+++ b/lib/literal/property.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class Literal::Property
-	ORDER = { :positional => 0, :* => 1, :keyword => 2, :** => 3, :& => 4 }.freeze
+	ORDER = { :positional => 0, :* => 1, :keyword => 2, :** => 3, :& => 4, :const => 5 }.freeze
 	RUBY_KEYWORDS = %i[alias and begin break case class def do else elsif end ensure false for if in module next nil not or redo rescue retry return self super then true undef unless until when while yield].to_h { |k| [k, "__#{k}__"] }.freeze
 
 	VISIBILITY_OPTIONS = Set[false, :private, :protected, :public].freeze
 	VISIBILITY_ORDER = { false => 0, :private => 1, :protected => 2, :public => 3 }.freeze
-	KIND_OPTIONS = Set[:positional, :*, :keyword, :**, :&].freeze
+	KIND_OPTIONS = Set[:positional, :*, :keyword, :**, :&, :const].freeze
 
 	include Comparable
 
@@ -61,6 +61,10 @@ class Literal::Property
 
 	def block?
 		@kind == :&
+	end
+
+	def const?
+		@kind == :const
 	end
 
 	# The instance variable this property is stored in. Generated code writes
@@ -204,8 +208,14 @@ class Literal::Property
 	end
 
 	def generate_initializer_handle_property(buffer = +"")
-		buffer << "  # " << @name.name << "\n" <<
-			"  __property__ = __properties__[:" << @name.name << "]\n"
+		buffer << "  # " << @name.name << "\n"
+
+		if const?
+			buffer << "  @" << @name.name << " = __properties__[:" << @name.name << "].default\n"
+			return buffer
+		end
+
+		buffer << "  __property__ = __properties__[:" << @name.name << "]\n"
 
 		if @kind == :keyword && ruby_keyword?
 			generate_initializer_escape_keyword(buffer)

--- a/lib/literal/struct.rb
+++ b/lib/literal/struct.rb
@@ -18,6 +18,10 @@ class Literal::Struct < Literal::DataStructure
 				&coercion
 			)
 		end
+
+		def const(name, value, reader: :public, description: nil)
+			super
+		end
 	end
 
 	def []=(key, value)

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -436,3 +436,21 @@ test "indexed access raises for invalid key types" do
 	person = Person.new(name: "John")
 	assert_raises(TypeError) { person[0] }
 end
+
+class ConstCircle < Literal::Data
+	const :kind, "circle"
+	prop :radius, Integer
+end
+
+test "consts appear in to_h and ==" do
+	circle = ConstCircle.new(radius: 1)
+
+	assert_equal circle.to_h, { radius: 1, kind: "circle" }
+	assert_equal circle, ConstCircle.new(radius: 1)
+end
+
+test "from_props fills an omitted const and checks a given one" do
+	assert_equal ConstCircle.from_props(radius: 1).kind, "circle"
+	assert_equal ConstCircle.from_props(radius: 1, kind: "circle").kind, "circle"
+	assert_raises(Literal::TypeError) { ConstCircle.from_props(radius: 1, kind: "square") }
+end

--- a/test/draft.test.rb
+++ b/test/draft.test.rb
@@ -381,3 +381,22 @@ test "Literal::Struct.build builds through a draft" do
 	assert_equal value.name, "John"
 	assert_equal value.id, 1
 end
+
+class DraftConstExample < Literal::Data
+	const :kind, "example"
+	prop :name, String
+end
+
+test "drafts carry consts as consts" do
+	draft = Literal::Draft(DraftConstExample).new
+
+	assert_equal draft.kind, "example"
+	refute draft.respond_to?(:kind=)
+	assert_equal draft.finalize(name: "Joel").kind, "example"
+end
+
+test "checking reports a const given a different value" do
+	assert Literal::Draft(DraftConstExample).check({ name: "Joel" }).success?
+	assert Literal::Draft(DraftConstExample).check({ name: "Joel", kind: "example" }).success?
+	refute Literal::Draft(DraftConstExample).check({ name: "Joel", kind: "other" }).success?
+end

--- a/test/properties.test.rb
+++ b/test/properties.test.rb
@@ -800,3 +800,40 @@ test "generated methods redefine without warnings" do
 
 	assert_equal [], warnings.grep(/method redefined/)
 end
+
+test "consts are assigned at initialization and are not initializer parameters" do
+	example = Class.new(Example) do
+		const :kind, "example", reader: :public
+		prop :name, String
+	end
+
+	instance = example.new(name: "Joel")
+
+	assert_equal instance.kind, "example"
+	refute instance.respond_to?(:kind=)
+	assert_raises(ArgumentError) { example.new(name: "Joel", kind: "other") }
+end
+
+test "a const value must be a frozen object, not nil or a Proc" do
+	assert_raises(Literal::ArgumentError) { Class.new(Example) { const :kind, +"unfrozen" } }
+	assert_raises(Literal::ArgumentError) { Class.new(Example) { const :kind, nil } }
+	assert_raises(Literal::ArgumentError) { Class.new(Example) { const :kind, -> { "example" } } }
+end
+
+test "a const cannot have a writer or a coercion" do
+	assert_raises(Literal::ArgumentError) do
+		Class.new(Example) { prop :kind, "example", :const, writer: :public, default: "example" }
+	end
+
+	assert_raises(Literal::ArgumentError) do
+		Class.new(Example) { prop(:kind, "example", :const, default: "example") { |value| value } }
+	end
+end
+
+test "a const cannot be redefined as a parameter" do
+	parent = Class.new(Example) { const :kind, "example" }
+
+	error = assert_raises(Literal::ArgumentError) { Class.new(parent) { prop :kind, String } }
+
+	assert error.message.include?("must match the inherited kind :const")
+end

--- a/test/properties/introspection.test.rb
+++ b/test/properties/introspection.test.rb
@@ -155,3 +155,17 @@ test "mixed property types with defaults and nilables" do
 	assert_equal WithOptionals.optional_positional_property_names, [:optional_pos, :optional_name]
 	assert_equal WithOptionals.optional_keyword_property_names, [:optional_kw, :tags, :created_at]
 end
+
+class WithConst
+	extend Literal::Properties
+	extend Literal::Properties::Introspection
+
+	const :kind, "example"
+	prop :name, String
+end
+
+test "consts are neither required nor keyword properties" do
+	assert_equal WithConst.required_property_names, [:name]
+	assert_equal WithConst.keyword_property_names, [:name]
+	assert_equal WithConst.positional_property_names, []
+end

--- a/test/serialization.test.rb
+++ b/test/serialization.test.rb
@@ -3305,3 +3305,31 @@ test "union of boolean consts serializes as a boolean" do
 	assert_equal Example.deserialize(false, type:), false
 	assert_equal Example.json_schema(type), { "type" => "boolean" }
 end
+
+class SerializationConstShape < Literal::Data
+	const :kind, "shape"
+	prop :sides, Integer
+end
+
+test "consts serialize, deserialize and emit a const schema" do
+	shape = SerializationConstShape.new(sides: 3)
+	serialized = Example.serialize(shape, type: SerializationConstShape)
+
+	assert_equal serialized, { "sides" => 3, "kind" => "shape" }
+	assert_equal Example.deserialize(serialized, type: SerializationConstShape), shape
+	assert_equal Example.deserialize({ "sides" => 3 }, type: SerializationConstShape), shape
+	assert_raises(Literal::TypeError) { Example.deserialize({ "sides" => 3, "kind" => "circle" }, type: SerializationConstShape) }
+
+	assert_equal(
+		Example.json_schema(SerializationConstShape),
+		{
+			"type" => "object",
+			"properties" => {
+				"sides" => { "type" => "integer" },
+				"kind" => { "type" => "string", "const" => "shape" },
+			},
+			"required" => ["sides"],
+			"additionalProperties" => false,
+		},
+	)
+end


### PR DESCRIPTION
## Summary

Adds `const`, a property whose value is fixed when the class is defined rather than when an instance is constructed.

```ruby
class Circle < Literal::Data
  const :kind, "circle"
  prop :radius, Integer
end

Circle.new(radius: 2).kind        # => "circle"
Circle.new(kind: "x", radius: 2)  # ArgumentError: unknown keyword: :kind
```

- A const is a property of kind `:const`. It takes no initializer parameter and has no writer.
- The value is frozen and doubles as the property's type, so `from_props` and deserialization accept a matching value and reject any other. An omitted value is filled in.
- Drafts carry consts unchanged. JSON Schema emits `const`. `to_h`, `==` and introspection treat it as an ordinary, non-required property.
- `const` delegates to `prop`, which validates that a const has no writer, coercion or seal, and that its value is neither nil nor a Proc.

The main use case is a discriminator tag on a tagged union, where each subclass declares its own const.

## Test plan

- [x] Full suite passes (3892 tests)
- [x] RuboCop clean on changed files
- [x] New tests cover initialization, validation, inheritance, `from_props`, drafts and soft checks, serialization and JSON Schema, and introspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
