### PR TITLE
Replace defaults by class; configurable TimeSerializer precision and UTC

### DIFF
--- a/lib/literal/serialization_context.rb
+++ b/lib/literal/serialization_context.rb
@@ -48,7 +48,10 @@ class Literal::SerializationContext
 	CacheLimit = 2048
 
 	def initialize(*serializers, defaults: true)
-		serializers = [*serializers, *DefaultSerializers] if defaults
+		if defaults
+			remaining_defaults = DefaultSerializers.reject { |default| serializers.any? { |supplied| supplied <= default } }
+			serializers = [*serializers, *remaining_defaults]
+		end
 
 		@type = _Deferred { @type }
 		@kind = _Deferred { @kind }

--- a/lib/literal/serializers/time_serializer.rb
+++ b/lib/literal/serializers/time_serializer.rb
@@ -5,6 +5,39 @@ require "time"
 
 class Literal::TimeSerializer < Literal::Serializer
 	Type = _Union(Time, DateTime)
+	Precision = _Nilable(_Integer(0..9))
+
+	def self.with(precision: nil, utc: false)
+		check_precision(precision)
+		options = { precision:, utc: }
+
+		Class.new(self) do
+			define_method(:initialize) { |context, **overrides| super(context, **options, **overrides) }
+
+			define_singleton_method(:name) do
+				"#{superclass.name}.with(#{options.map { |key, value| "#{key.name}: #{value.inspect}" }.join(', ')})"
+			end
+
+			singleton_class.alias_method(:to_s, :name)
+			singleton_class.alias_method(:inspect, :name)
+		end
+	end
+
+	def self.check_precision(precision)
+		unless Precision === precision
+			raise Literal::ArgumentError, "precision must be nil or an Integer in 0..9, got #{precision.inspect}"
+		end
+	end
+
+	def initialize(context, precision: nil, utc: false)
+		super(context)
+		self.class.check_precision(precision)
+		@precision = precision
+		@utc = utc
+	end
+
+	attr_reader :precision
+	attr_reader :utc
 
 	def type
 		Type
@@ -58,17 +91,26 @@ class Literal::TimeSerializer < Literal::Serializer
 	end
 
 	private def serialize_time(value)
-		fraction = case value
-			when Time
-				value.subsec
-			when DateTime
-				value.sec_fraction
-		end
+		digits = @precision || (fraction_of(value).zero? ? 0 : 9)
 
-		if fraction.zero?
-			value.iso8601
-		else
-			value.iso8601(9)
+		case value
+		when Time
+			@utc ? value.getutc.iso8601(digits) : value.iso8601(digits)
+		when DateTime
+			if @utc
+				"#{value.new_offset(0).iso8601(digits).delete_suffix('+00:00')}Z"
+			else
+				value.iso8601(digits)
+			end
+		end
+	end
+
+	private def fraction_of(value)
+		case value
+		when Time
+			value.subsec
+		when DateTime
+			value.sec_fraction
 		end
 	end
 end

--- a/llms.md
+++ b/llms.md
@@ -186,13 +186,13 @@ Type-failure messages speak a deliberately small public vocabulary — `"must be
 ## Serialization (JSON data + JSON Schema)
 
 ```ruby
-ctx = Literal::SerializationContext.new  # frozen; custom serializers/codecs may be passed first
+ctx = Literal::SerializationContext.new  # frozen; custom serializers/codecs passed first; one whose class is or descends from a default replaces that default
 ctx.serialize(v, type: T)                # → JSON data (strict-checks both sides)
 ctx.deserialize(raw, type: T)
 ctx.json_schema(T)                       # $defs for recursion
 ```
 
-First-match over ordered serializer list, shallow `handles_type?`; recursion/cycle legality central (cycles must pass a referenceable node → `$ref`). Custom scalar mapping: subclass `Literal::Serializer::Codec` — `type` (class), `encoded_type` (nullary fixed wire type), `encode(v)`, `decode(raw)`; children handled by encoded type's serializer. Parameterized generics need the full `Literal::Serializer` protocol.
+First-match over ordered serializer list, shallow `handles_type?`; recursion/cycle legality central (cycles must pass a referenceable node → `$ref`). Custom scalar mapping: subclass `Literal::Serializer::Codec` — `type` (class), `encoded_type` (nullary fixed wire type), `encode(v)`, `decode(raw)`; children handled by encoded type's serializer. Parameterized generics need the full `Literal::Serializer` protocol. `Literal::TimeSerializer.with(precision: 3, utc: true)` returns a configured subclass (`precision:` nil = adaptive, or 0..9 fixed fraction digits; `utc:` converts to UTC, output ends in `Z`) that replaces the default TimeSerializer when passed to the context.
 
 Notables: DataStructures = closed objects via props/`from_props`; enums = backing value; `_Optional` props omitted on write, restored to Undefined on read (never defaulted); untagged unions must be natural (members distinguishable by JSON type or object shape); `_TaggedUnion` writes `"$type"` discriminator (merged into object members, else `{"$type":, "value":}`); non-string-keyed Hashes → arrays of pairs; `description:` → schema.
 

--- a/test/serialization.test.rb
+++ b/test/serialization.test.rb
@@ -335,6 +335,14 @@ class SerializationTask < Literal::Data
 	prop :priority, SerializationPriority
 end
 
+class SerializationCustomTimeSerializer < Literal::TimeSerializer
+end
+
+class SerializationStamped < Literal::Data
+	prop :at, Time
+	prop :maybe, _Nilable(Time)
+end
+
 Example = Literal::SerializationContext.new
 
 test "serialization context includes default serializers" do
@@ -347,6 +355,120 @@ test "serialization context defaults can be disabled" do
 
 	assert context.kind === String
 	refute context.kind === Integer
+end
+
+test "serialization context replaces the default of a supplied serializer's class" do
+	context = Literal::SerializationContext.new(Literal::TimeSerializer.with(precision: 3, utc: true))
+
+	assert_equal context.serializers.count { |serializer| Literal::TimeSerializer === serializer }, 1
+	assert_equal context.serializers.length, Literal::SerializationContext::DefaultSerializers.length
+	assert context.kind === Time
+	assert context.kind === DateTime
+end
+
+test "serialization context replaces the default of a supplied subclass" do
+	context = Literal::SerializationContext.new(SerializationCustomTimeSerializer)
+
+	assert_equal context.serializers.count { |serializer| Literal::TimeSerializer === serializer }, 1
+	assert SerializationCustomTimeSerializer === context.serializers.first
+end
+
+test "serialization context keeps every default when supplied a plain default class" do
+	context = Literal::SerializationContext.new(Literal::TimeSerializer)
+	time = Time.new(2025, 1, 13, 20, 30, 45.123456789r, "+01:00")
+
+	assert_equal context.serializers.map(&:class).sort_by(&:name), Literal::SerializationContext::DefaultSerializers.sort_by(&:name)
+	assert_equal context.serialize(time, type: Time), Example.serialize(time, type: Time)
+end
+
+test "serialization context keeps every default when supplied a codec" do
+	context = Literal::SerializationContext.new(SerializationMoneyCodec)
+
+	assert_equal context.serializers.length, Literal::SerializationContext::DefaultSerializers.length + 1
+	assert_equal context.serializers.count { |serializer| Literal::TimeSerializer === serializer }, 1
+end
+
+test "serialization context without defaults ignores the replacement rule" do
+	context = Literal::SerializationContext.new(Literal::TimeSerializer.with(utc: true), defaults: false)
+
+	assert_equal context.serializers.length, 1
+	refute context.kind === String
+end
+
+test "time serializer precision and utc" do
+	time = Time.new(2024, 1, 15, 10, 20, 30.123456, "-08:00")
+	whole = Time.new(2024, 1, 15, 10, 20, 30, "-08:00")
+	datetime = DateTime.new(2024, 1, 15, 10, 20, 30 + (123_456r / 1_000_000), "-08:00")
+
+	utc = Literal::SerializationContext.new(Literal::TimeSerializer.with(precision: 3, utc: true))
+	nine = Literal::SerializationContext.new(Literal::TimeSerializer.with(precision: 9))
+	zero = Literal::SerializationContext.new(Literal::TimeSerializer.with(precision: 0))
+	local = Literal::SerializationContext.new(Literal::TimeSerializer.with(precision: 3))
+
+	assert_equal utc.serialize(time, type: Time), "2024-01-15T18:20:30.123Z"
+	assert_equal utc.serialize(datetime, type: DateTime), "2024-01-15T18:20:30.123Z"
+	assert_equal nine.serialize(whole, type: Time), "2024-01-15T10:20:30.000000000-08:00"
+	assert_equal zero.serialize(time, type: Time), "2024-01-15T10:20:30-08:00"
+	assert_equal local.serialize(time, type: Time), "2024-01-15T10:20:30.123-08:00"
+
+	assert_equal utc.deserialize("2024-01-15T18:20:30.123Z", type: Time), Time.new(2024, 1, 15, 10, 20, 30.123r, "-08:00")
+	assert_equal utc.deserialize("2024-01-15T18:20:30.123Z", type: DateTime), DateTime.new(2024, 1, 15, 18, 20, 30 + (123r / 1000), "+00:00")
+
+	assert_equal Example.serialize(time, type: Time), "2024-01-15T10:20:30.123456000-08:00"
+	assert_equal Example.serialize(whole, type: Time), "2024-01-15T10:20:30-08:00"
+	assert_equal Example.serialize(time, type: Time), Literal::SerializationContext.new(Literal::TimeSerializer.with).serialize(time, type: Time)
+end
+
+test "time serializer precision must be nil or an integer in 0..9" do
+	[10, -1, 3.5, "3"].each do |precision|
+		assert_raises(ArgumentError) { Literal::TimeSerializer.with(precision:) }
+		assert_raises(ArgumentError) { Literal::TimeSerializer.new(Example, precision:) }
+	end
+
+	Literal::TimeSerializer.with(precision: 0)
+	Literal::TimeSerializer.with(precision: 9)
+end
+
+test "configured time serializer subclass has a readable name" do
+	serializer = Literal::TimeSerializer.with(precision: 3, utc: true)
+
+	assert_equal serializer.name, "Literal::TimeSerializer.with(precision: 3, utc: true)"
+	assert_equal serializer.inspect, "Literal::TimeSerializer.with(precision: 3, utc: true)"
+	assert_equal serializer.to_s, "Literal::TimeSerializer.with(precision: 3, utc: true)"
+end
+
+test "configured time serializer applies inside structures, arrays, maps and nilables" do
+	context = Literal::SerializationContext.new(Literal::TimeSerializer.with(precision: 3, utc: true))
+	time = Time.new(2024, 1, 15, 10, 20, 30.123456, "-08:00")
+	stamped = SerializationStamped.new(at: time, maybe: nil)
+
+	assert_equal context.serialize(stamped, type: SerializationStamped), { "at" => "2024-01-15T18:20:30.123Z", "maybe" => nil }
+	assert_equal context.serialize([time], type: _Array(Time)), ["2024-01-15T18:20:30.123Z"]
+	assert_equal context.serialize({ "a" => time }, type: _Hash(String, Time)), { "a" => "2024-01-15T18:20:30.123Z" }
+	assert_equal context.serialize({ at: time }, type: _Map(at: Time)), { "at" => "2024-01-15T18:20:30.123Z" }
+	assert_equal context.serialize(time, type: _Nilable(Time)), "2024-01-15T18:20:30.123Z"
+	assert_equal context.serialize(nil, type: _Nilable(Time)), nil
+end
+
+test "configured time serializer formats json schema consts" do
+	context = Literal::SerializationContext.new(Literal::TimeSerializer.with(precision: 3, utc: true))
+	time = Time.new(2024, 1, 15, 10, 20, 30.123456, "-08:00")
+	datetime = DateTime.new(2024, 1, 15, 10, 20, 30, "-08:00")
+
+	assert_equal(
+		context.json_schema(time),
+		{ "type" => "string", "format" => "date-time", "const" => "2024-01-15T18:20:30.123Z" },
+	)
+
+	assert_equal(
+		context.json_schema(_Constraint(DateTime, datetime)),
+		{ "type" => "string", "format" => "date-time", "const" => "2024-01-15T18:20:30.000Z" },
+	)
+
+	assert_equal(
+		context.json_schema(SerializationStamped)["properties"]["at"],
+		{ "type" => "string", "format" => "date-time" },
+	)
 end
 
 test "string length range serialization" do


### PR DESCRIPTION
## Summary

- `Literal::SerializationContext.new(*serializers)` now removes a default serializer when a supplied serializer's class is, or descends from, that default's class. Supplied serializers stay ahead of the defaults, so dispatch order is otherwise unchanged. Codecs and unrelated serializers still coexist with the defaults; `defaults: false` is unchanged.
- `Literal::TimeSerializer` takes `precision:` (`nil` keeps the adaptive behaviour, `0..9` emits fixed fraction digits, anything else raises `ArgumentError`) and `utc:` (converts with `getutc` / `new_offset(0)` before formatting, so output ends in `Z`). Defaults reproduce the previous output byte for byte. Deserialization is unchanged. JSON Schema `const` values, including the constraint-type path, use the same formatting as `serialize`.
- `Literal::TimeSerializer.with(precision: 3, utc: true)` returns a configured subclass that keeps the `new(context)` protocol, is recognised by the replacement rule, and reports a readable `name` / `inspect`.

```ruby
Literal::SerializationContext.new(
  MyCodec,
  Literal::TimeSerializer.with(precision: 3, utc: true)
)
```

## Notes

- Ruby formats a zero-offset `DateTime` as `+00:00`, so that suffix is swapped for `Z` on the DateTime path.
- `utc: true` round trips preserve the instant, not the original offset.
- llms.md is updated. README.md has no serialization documentation, so it is untouched.

## Test plan

- [x] `mise run test`: 3905 passed, 0 failed
- [x] New tests in `test/serialization.test.rb` cover replacement (exact class, subclass, plain default, codec, `defaults: false`), formatting (`precision: 3, utc: true` on `-08:00` gives `2024-01-15T18:20:30.123Z`, `precision: 9` on a whole second, `precision: 0`, `utc: false`, DateTime), invalid precision, the generated name, nesting in structures / arrays / hashes / maps / nilables, and JSON Schema consts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
