### PR TITLE
Fix constant tracker retaining unloaded owners

### DIFF
--- a/lib/literal/constant_tracker.rb
+++ b/lib/literal/constant_tracker.rb
@@ -1,12 +1,33 @@
 # frozen_string_literal: true
 
+require "weakref"
+
 module Literal::ConstantTracker
 	CONST_GET_METHOD = Module.instance_method(:const_get)
 	CONSTANTS = ObjectSpace::WeakKeyMap.new
 	EMPTY_REFERENCES = [].freeze
 
-	Reference = Data.define(:owner, :const) do
+	# A strong owner would keep its constant value alive through this map's
+	# values, defeating the weak key when the owner is unloaded.
+	Reference = Data.define(:owner_ref, :const) do
+		def owner
+			owner_ref.__getobj__
+		rescue WeakRef::RefError
+			nil
+		end
+
+		def current?(object)
+			owner = self.owner
+			owner && !owner.autoload?(const, false) && owner.const_defined?(const, false) &&
+				CONST_GET_METHOD.bind_call(owner, const, false).equal?(object)
+		rescue NameError
+			false
+		end
+
 		def name
+			owner = self.owner
+			return unless owner
+
 			if owner == Object
 				const.to_s
 			elsif owner.name
@@ -16,11 +37,17 @@ module Literal::ConstantTracker
 			end
 		end
 
-		alias_method :to_s, :name
+		def to_s
+			name.to_s
+		end
 	end
 
 	def self.const_ref(object)
-		CONSTANTS[object] || EMPTY_REFERENCES
+		references = CONSTANTS[object]
+		return EMPTY_REFERENCES unless references
+
+		references.select! { |reference| reference.current?(object) }
+		references.empty? ? EMPTY_REFERENCES : references
 	rescue
 		EMPTY_REFERENCES
 	end
@@ -37,7 +64,10 @@ module Literal::ConstantTracker
 		return super if object in Literal::Immediate
 
 		begin
-			(CONSTANTS[object] ||= []) << Reference.new(self, const)
+			references = Literal::ConstantTracker.const_ref(object).reject do |reference|
+				reference.owner.equal?(self) && reference.const == const
+			end
+			CONSTANTS[object] = references << Reference.new(WeakRef.new(self), const)
 		rescue
 			# object is not weak-keyable or hashable.
 			return super

--- a/test/constant_tracker.test.rb
+++ b/test/constant_tracker.test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "weakref"
+
 Object.const_set(:ConstantTrackerTopLevelObject, Object.new)
 Object.const_set(:ConstantTrackerTest, Module.new)
 
@@ -57,4 +59,108 @@ end
 test "returns frozen empty references for untracked constants" do
 	assert_equal Literal.const_ref(ConstantTrackerTest::IntegerValue), []
 	assert Literal.const_ref(ConstantTrackerTest::IntegerValue).frozen?
+end
+
+test "does not retain removed classes or modules through their constants" do
+	references = Thread.new do
+		[Class, Module].flat_map do |type|
+			3.times.map do
+				Object.const_set(:ConstantTrackerReloadedOwner, type.new)
+				ConstantTrackerReloadedOwner.const_set(:Payload, Object.new)
+				reference = WeakRef.new(ConstantTrackerReloadedOwner)
+				Object.__send__(:remove_const, :ConstantTrackerReloadedOwner)
+				reference
+			end
+		end
+	end.value
+
+	3.times { GC.start }
+	refute references.any?(&:weakref_alive?)
+end
+
+test "does not retain an owner when its constant value is still alive" do
+	object = Object.new
+	reference = Thread.new do
+		owner = Module.new
+		owner.const_set(:Payload, object)
+		WeakRef.new(owner)
+	end.value
+
+	3.times { GC.start }
+	refute reference.weakref_alive?
+	assert_equal Literal.const_ref(object), []
+end
+
+test "preserves live aliases through garbage collection" do
+	object = Object.new
+	owner = Module.new
+	owner.const_set(:First, object)
+	owner.const_set(:Second, object)
+
+	3.times { GC.start }
+	references = Literal.const_ref(object)
+	assert_equal references.map(&:owner), [owner, owner]
+	assert_equal references.map(&:const), [:First, :Second]
+end
+
+test "drops removed and replaced constant references" do
+	object = Object.new
+	owner = Module.new
+	owner.const_set(:Removed, object)
+	owner.const_set(:Replaced, object)
+	owner.const_set(:Kept, object)
+	owner.__send__(:remove_const, :Removed)
+	owner.__send__(:remove_const, :Replaced)
+	owner.const_set(:Replaced, Object.new)
+
+	assert_equal Literal.const_ref(object).map(&:const), [:Kept]
+end
+
+test "updates references when an anonymous owner receives a name" do
+	owner = Module.new
+	owner.const_set(:Payload, Object.new)
+	reference = Literal.const_ref(owner::Payload).first
+	assert_equal reference.name, "#<anonymous Module>::Payload"
+
+	Object.const_set(:ConstantTrackerNamedOwner, owner)
+	assert_equal reference.name, "ConstantTrackerNamedOwner::Payload"
+ensure
+	Object.__send__(:remove_const, :ConstantTrackerNamedOwner)
+end
+
+test "a saved reference does not keep its owner alive" do
+	reference = Thread.new do
+		owner = Module.new
+		owner.const_set(:Payload, Object.new)
+		Literal.const_ref(owner::Payload).first
+	end.value
+
+	3.times { GC.start }
+	assert_equal reference.owner, nil
+	assert_equal reference.name, nil
+	assert_equal reference.to_s, ""
+end
+
+test "registering the same constant again does not accumulate references" do
+	object = Object.new
+	owner = Module.new
+	owner.const_set(:Payload, object)
+
+	3.times do
+		owner.__send__(:remove_const, :Payload)
+		owner.const_set(:Payload, object)
+	end
+
+	assert_equal Literal.const_ref(object).map(&:const), [:Payload]
+end
+
+test "discarding stale references does not trigger autoloads" do
+	object = Object.new
+	owner = Module.new
+	owner.const_set(:Payload, object)
+	owner.__send__(:remove_const, :Payload)
+	owner.autoload(:Payload, "constant_tracker_should_not_load")
+
+	assert_equal Literal.const_ref(object), []
+	assert_equal owner.autoload?(:Payload), "constant_tracker_should_not_load"
 end


### PR DESCRIPTION
Unloaded classes and modules remain reachable through `Literal::ConstantTracker`, even though `CONSTANTS` uses an `ObjectSpace::WeakKeyMap`. This changes tracked owners to weak references so development reloads can release the previous generation.

@joeldrapper, the reproduction and proposed fix are below for your review.

### Root cause

`WeakKeyMap` holds its values strongly. Each value contains a `Reference` that currently holds its owner strongly, and the owner holds the constant value used as the weak key:

```text
CONSTANTS → references → owner → constant value (weak key)
```

Removing the owner's top-level constant does not break that path. An owner with even one object-valued constant can therefore remain alive indefinitely.

The standalone reproduction below isolates this retention without Rails or any application code.

### Reproduction

Run with Literal loaded from the checkout under test:

```ruby
require "literal"
require "weakref"

references = 5.times.map do
  Object.const_set(:MemoryProbeOwner, Class.new)
  MemoryProbeOwner.const_set(:Payload, Object.new)
  reference = WeakRef.new(MemoryProbeOwner)
  Object.__send__(:remove_const, :MemoryProbeOwner)
  reference
end

3.times { GC.start }
puts references.count(&:weakref_alive?)
```

On Ruby 4.0.5 at `7359d8be4229b3110d6f2e8561cb62296cf6eaa9`, this prints **5**. With this patch it prints **0**. In a separate diagnostic process, clearing only `Literal::ConstantTracker::CONSTANTS` also allowed all five owners to be collected on the unpatched version.

### Proposed fix

- Store the owner in a `WeakRef`, keeping `reference.owner` as the accessor for the live module or class. A collected owner returns `nil`; its reference has no name and stringifies to an empty string.
- Prune collected owners and removed/replaced bindings when looking up references, without triggering autoloads.
- Avoid duplicate entries when the same owner registers the same constant again. Preserve live aliases and resolve owner names dynamically, including when an anonymous owner is named later.

### Validation

- Added eight regression tests covering collection of unloaded classes/modules, externally retained values, saved references, live aliases, anonymous owner naming, stale bindings, repeat registration, and pending autoloads.
- Full Quickdraw suite on Ruby 4.0.5: **3,919 passed, 0 failed, 0 errors** (`bundle exec qt -p 1 -t 1`, the repository test task's command with explicit worker limits).
- RuboCop: both changed files pass. `git diff --check` passes.
- Local validation used an isolated dependency bundle with the repository's pinned Quickdraw revision; the Ruby-version matrix remains for CI.
